### PR TITLE
Fix missing hook import on profile page

### DIFF
--- a/app/profile/page.jsx
+++ b/app/profile/page.jsx
@@ -9,6 +9,7 @@ import { setLoading } from '../../store/userSlice.js';
 import axios from "axios";
 
 import { useState, useEffect } from "react";
+import useFetchUser from "@/hooks/useFetchUser";
 import { signOut, updateProfile } from "firebase/auth";
 import { auth, db } from "../../firebaseConfig";
 import { doc, updateDoc } from "firebase/firestore";


### PR DESCRIPTION
## Summary
- import `useFetchUser` in profile page

## Testing
- `npm run lint`
- `npm run build` *(fails: Providers is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687c79eac218832c89b497b4d55b3756