### PR TITLE
Fix missing Providers import in RootLayout

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,7 +1,6 @@
 
 "use client";
-import { Provider } from "react-redux";
-import { store } from "@/store/store";
+import Providers from "../components/Providers";
 
 export default function RootLayout({ children }) {
   return (


### PR DESCRIPTION
## Summary
- fix RootLayout by importing Providers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c7afcf144832ca669c3bf5776ba5d